### PR TITLE
Fix missing required packages from examples folder

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -6,8 +6,10 @@
   "author": "Rosco Kalis <rosco@bitcoin.com>",
   "license": "MIT",
   "dependencies": {
+    "@types/node": "^12.7.8",
     "bitbox-sdk": "^8.4.0",
     "bitcoincashjs-lib": "Bitcoin-com/bitcoincashjs-lib#v4.0.1",
-    "cashscript": "^0.2.1-beta"
+    "cashscript": "^0.2.1-beta",
+    "typescript": "^3.6.4"
   }
 }


### PR DESCRIPTION
Fix for #36.

Added typescript and @types/node to examples/ dir.