### PR TITLE
Add BitcoinRpcNetworkProvider

### DIFF
--- a/packages/cashscript/package.json
+++ b/packages/cashscript/package.json
@@ -43,6 +43,7 @@
   "dependencies": {
     "@bitauth/libauth": "^1.17.2",
     "bip68": "^1.0.4",
+    "bitcoin-rpc-promise-retry": "^1.3.0",
     "cashc": "^0.5.7",
     "delay": "^4.3.0",
     "electrum-cash": "^2.0.4",

--- a/packages/cashscript/package.json
+++ b/packages/cashscript/package.json
@@ -46,7 +46,7 @@
     "bitcoin-rpc-promise-retry": "^1.3.0",
     "cashc": "^0.5.7",
     "delay": "^4.3.0",
-    "electrum-cash": "^2.0.4",
+    "electrum-cash": "^2.0.6",
     "hash.js": "^1.1.7"
   },
   "devDependencies": {

--- a/packages/cashscript/src/network/BitcoinRpcNetworkProvider.ts
+++ b/packages/cashscript/src/network/BitcoinRpcNetworkProvider.ts
@@ -1,0 +1,40 @@
+import RpcClientRetry from 'bitcoin-rpc-promise-retry';
+import { Utxo, Network } from '../interfaces';
+import NetworkProvider from './NetworkProvider';
+
+export default class BitcoinRpcNetworkProvider implements NetworkProvider {
+  private rpcClient: RpcClientRetry;
+
+  constructor(
+    public network: Network,
+    url: string,
+    opts?: object,
+  ) {
+      this.rpcClient = new RpcClientRetry(url, opts);
+  }
+
+  async getUtxos(address: string): Promise<Utxo[]> {
+    return (await this.rpcClient.listUnspent(0, 9999999, [ address ]))
+      .map((u) => ({
+        txid: u.txid,
+        vout: u.vout,
+        satoshis: u.amount * 100000000,
+      }));
+  }
+
+  async getBlockHeight(): Promise<number> {
+    return this.rpcClient.getBlockCount();
+  }
+
+  async getRawTransaction(txid: string): Promise<string> {
+    return this.rpcClient.getRawTransaction(txid);
+  }
+
+  async sendRawTransaction(txHex: string): Promise<string> {
+    return this.rpcClient.sendRawTransaction(txHex);
+  }
+
+  getClient(): RpcClientRetry {
+      return this.rpcClient;
+  }
+}

--- a/packages/cashscript/src/network/BitcoinRpcNetworkProvider.ts
+++ b/packages/cashscript/src/network/BitcoinRpcNetworkProvider.ts
@@ -10,16 +10,19 @@ export default class BitcoinRpcNetworkProvider implements NetworkProvider {
     url: string,
     opts?: object,
   ) {
-      this.rpcClient = new RpcClientRetry(url, opts);
+    this.rpcClient = new RpcClientRetry(url, opts);
   }
 
   async getUtxos(address: string): Promise<Utxo[]> {
-    return (await this.rpcClient.listUnspent(0, 9999999, [ address ]))
-      .map((u) => ({
-        txid: u.txid,
-        vout: u.vout,
-        satoshis: u.amount * 100000000,
-      }));
+    const result = await this.rpcClient.listUnspent(0, 9999999, [address]);
+
+    const utxos = result.map((utxo) => ({
+      txid: utxo.txid,
+      vout: utxo.vout,
+      satoshis: utxo.amount * 1e8,
+    }));
+
+    return utxos;
   }
 
   async getBlockHeight(): Promise<number> {
@@ -35,6 +38,6 @@ export default class BitcoinRpcNetworkProvider implements NetworkProvider {
   }
 
   getClient(): RpcClientRetry {
-      return this.rpcClient;
+    return this.rpcClient;
   }
 }

--- a/packages/cashscript/src/network/ElectrumNetworkProvider.ts
+++ b/packages/cashscript/src/network/ElectrumNetworkProvider.ts
@@ -75,7 +75,7 @@ export default class ElectrumNetworkProvider implements NetworkProvider {
     return await this.performRequest('blockchain.transaction.broadcast', txHex) as string;
   }
 
-  async connectCluster(): Promise<boolean[]> {
+  async connectCluster(): Promise<void[]> {
     try {
       return await this.electrum.startup();
     } catch (e) {

--- a/packages/cashscript/src/network/bitcoin-rpc-promise-retry.d.ts
+++ b/packages/cashscript/src/network/bitcoin-rpc-promise-retry.d.ts
@@ -1,0 +1,32 @@
+declare module 'bitcoin-rpc-promise-retry';
+
+interface ListUnspentItem {
+  txid: string;
+  vout: number;
+  address: string;
+  label: string;
+  scriptPubKey: string;
+  amount: number;
+  confirmations: number;
+  redeemScript: string;
+  spendable: boolean;
+  solvable: boolean;
+  safe: boolean;
+}
+
+interface RpcClientRetry {
+  constructor(url: string, opts?: object): void;
+  listUnspent(minconf?: number, maxconf?: number, addresses?: string[], include_unsafe?: boolean, query_options?: object): Promise<ListUnspentItem[]>;
+  getBlockCount(): Promise<number>;
+  getRawTransaction(txid: string, verbose?: boolean, blockhash?: string): Promise<string>;
+  sendRawTransaction(hexstring: string, allowhighfees?: boolean): Promise<string>;
+
+  // below are not required for NetworkProvider interface, but very useful
+  generate(nblocks: number, maxtries?: number): Promise<string[]>;
+  generateToAddress(nblocks: number, address: string, maxtries?: number): Promise<string[]>;
+  getNewAddress(label?: string): Promise<string>;
+  dumpPrivKey(address: string): Promise<string>;
+  getBalance(dummy?: string, minconf?: number, include_watchonly?: boolean): Promise<number>;
+  getBlock(blockhash: string, verbosity?: number): Promise<string>;
+  importAddress(address: string, label?: string, rescan?: boolean, p2sh?: boolean): Promise<void>;
+}

--- a/packages/cashscript/src/network/bitcoin-rpc-promise-retry.d.ts
+++ b/packages/cashscript/src/network/bitcoin-rpc-promise-retry.d.ts
@@ -1,3 +1,4 @@
+/* eslint-disable */
 declare module 'bitcoin-rpc-promise-retry';
 
 interface ListUnspentItem {

--- a/packages/cashscript/src/network/index.ts
+++ b/packages/cashscript/src/network/index.ts
@@ -1,4 +1,5 @@
 export { default as NetworkProvider } from './NetworkProvider';
 export { default as BitboxNetworkProvider } from './BitboxNetworkProvider';
+export { default as BitcoinRpcNetworkProvider } from './BitcoinRpcNetworkProvider';
 export { default as ElectrumNetworkProvider } from './ElectrumNetworkProvider';
 export { default as FullStackNetworkProvider } from './FullStackNetworkProvider';

--- a/yarn.lock
+++ b/yarn.lock
@@ -2741,6 +2741,13 @@ bitbox-sdk@^8.11.1, bitbox-sdk@^8.8.0:
     socket.io-client "^2.2.0"
     wif "^2.0.6"
 
+bitcoin-rpc-promise-retry@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/bitcoin-rpc-promise-retry/-/bitcoin-rpc-promise-retry-1.3.0.tgz#28a9f5aa7b5528b0518b0bcccde63e7384e1626b"
+  integrity sha512-xhldBhYwiUNY4spzkXXcU9LEq+nbSKJ5tvYWEUe/XTCe1VYoe8tEb5jJq4MBA2d+5egiUOA+P1QTTYm1FqPtOg==
+  dependencies:
+    bitcoind-rpc "^0.8.0"
+
 bitcoincash-ops@Bitcoin-com/bitcoincash-ops#2.0.0, "bitcoincash-ops@github:Bitcoin-com/bitcoincash-ops#2.0.0":
   version "2.0.0"
   resolved "https://codeload.github.com/Bitcoin-com/bitcoincash-ops/tar.gz/6ab82cc7326c67236f3b2d9d0457258ac2ef48e3"
@@ -2793,6 +2800,11 @@ bitcoincashjs@^0.1.10:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/bitcoincashjs/-/bitcoincashjs-0.1.14.tgz#9da1efb762e05d608b6e04fadf1277eaa2201b48"
   integrity sha512-x0wMVSCZ56ZQnSQ+Xim7XfS0IYiOyOwo0pdMCmR+cDNB7zRhICFuH5i3lNdLSgUw1e7Pc3FmUlC9wruQNlYMnA==
+
+bitcoind-rpc@^0.8.0:
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/bitcoind-rpc/-/bitcoind-rpc-0.8.1.tgz#11889972e46c346870d26cf680e3a7e3e52b1ff1"
+  integrity sha512-NfhykAT/x/P1SOiog8UzltvTiv6A6d2X5VWJ3UjGeAqFLXv+IYHy+E4fFCBmgQRyIb1EIcyIZK1SVpSOGRHsaw==
 
 bitcoinjs-message@^2.0.0:
   version "2.1.1"
@@ -4083,10 +4095,10 @@ ecurve@^1.0.0, ecurve@^1.0.6:
     bigi "^1.1.0"
     safe-buffer "^5.0.1"
 
-electrum-cash@^2.0.4:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-2.0.4.tgz#926158323b9dbf6563298a32864d9a2a1a0deca0"
-  integrity sha512-9l4/MpHvJEvnfTqTM5/acPMosTC2lwmgl8JBAsOPJ417DgkUQV73yE3WqmTTvON+pBetj11hOUVAkpkaJv0X0A==
+electrum-cash@^2.0.6:
+  version "2.0.6"
+  resolved "https://registry.yarnpkg.com/electrum-cash/-/electrum-cash-2.0.6.tgz#005aa46ddace872696a89d918640ff6254a1ddaa"
+  integrity sha512-+o0Hqcl0eCwd9fvCJpWn4yV3gYX874uCGpwpwNbZuEU9ipY5ft9iU0IfuFghUN6/AuCcsE6f8JkVOjuTjmfF5Q==
   dependencies:
     "@types/ws" "^7.2.6"
     async-mutex "^0.2.4"


### PR DESCRIPTION
This adds a new network for interacting directly with a bitcoin cash node over rpc. It is based on http://github.com/blockparty-sh/cashscript-regtest